### PR TITLE
Removing ktlint dependency

### DIFF
--- a/buildSrc/src/main/kotlin/LintDependency.kt
+++ b/buildSrc/src/main/kotlin/LintDependency.kt
@@ -2,6 +2,4 @@ object LintDependency {
 
     const val DETEKT_PLUGIN = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Version.Lint.DETEKT}"
     const val DETEKT_FORMATTING = "io.gitlab.arturbosch.detekt:detekt-formatting:${Version.Lint.DETEKT}"
-
-    const val KTLINT = "org.jlleitschuh.gradle:ktlint-gradle:${Version.Lint.KTLINT}"
 }

--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -46,7 +46,6 @@ class Version {
 
     object Lint {
         const val DETEKT = "1.22.0-RC3"
-        const val KTLINT = "10.3.0"
     }
 
     object Test {

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/dependencies/LintDependency.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/dependencies/LintDependency.kt
@@ -4,6 +4,4 @@ object LintDependency {
 
     const val DETEKT_PLUGIN = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Version.Lint.DETEKT}"
     const val DETEKT_FORMATTING = "io.gitlab.arturbosch.detekt:detekt-formatting:${Version.Lint.DETEKT}"
-
-    const val KTLINT = "org.jlleitschuh.gradle:ktlint-gradle:${Version.Lint.KTLINT}"
 }

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/dependencies/Version.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/dependencies/Version.kt
@@ -48,7 +48,6 @@ class Version {
 
     object Lint {
         const val DETEKT = "1.22.0-RC3"
-        const val KTLINT = "10.3.0"
     }
 
     object Test {


### PR DESCRIPTION
## Goal

Removing ktlint dependency because the project is using the detekt formatting that provides the wrapper to this.