### PR TITLE
Migrate to typesafe project

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,9 +10,9 @@ dependencies {
         )
     )
 
-    implementation(project(":common"))
-    implementation(project(":network"))
-    implementation(project(":feature"))
+    implementation(projects.common)
+    implementation(projects.network)
+    implementation(projects.feature)
 
     debugImplementation(libs.leakcanary)
 }

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -7,8 +7,8 @@ android {
 }
 
 dependencies {
-    implementation(project(":common"))
-    implementation(project(":network"))
+    implementation(projects.common)
+    implementation(projects.network)
 
     implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.constraintlayout)

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/config/AndroidConfig.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/config/AndroidConfig.kt
@@ -1,6 +1,6 @@
 package br.com.jonathanarodr.playmovie.gradlebuild.config
 
-object AndroidConfig {
+internal object AndroidConfig {
 
     const val APPLICATION_ID = "br.com.jonathanarodr.playmovie"
 

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/config/ModuleConfig.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/config/ModuleConfig.kt
@@ -1,0 +1,5 @@
+package br.com.jonathanarodr.playmovie.gradlebuild.config
+
+internal object ModuleConfig {
+    const val testing: String = ":testing"
+}

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/config/PlatformConfig.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/config/PlatformConfig.kt
@@ -2,6 +2,6 @@ package br.com.jonathanarodr.playmovie.gradlebuild.config
 
 import org.gradle.api.JavaVersion
 
-data class PlatformConfig(
+internal data class PlatformConfig(
     val javaVersion: JavaVersion = JavaVersion.VERSION_11
 )

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidApplicationPlugin.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidApplicationPlugin.kt
@@ -3,6 +3,7 @@ package br.com.jonathanarodr.playmovie.gradlebuild.plugins
 import br.com.jonathanarodr.playmovie.gradlebuild.androidTestImplementation
 import br.com.jonathanarodr.playmovie.gradlebuild.apply
 import br.com.jonathanarodr.playmovie.gradlebuild.config.AndroidConfig
+import br.com.jonathanarodr.playmovie.gradlebuild.config.ModuleConfig
 import br.com.jonathanarodr.playmovie.gradlebuild.convention.configureAndroidAppicationConvention
 import br.com.jonathanarodr.playmovie.gradlebuild.convention.configureAndroidTestConvention
 import br.com.jonathanarodr.playmovie.gradlebuild.convention.configureBuildTypeConvention
@@ -55,8 +56,8 @@ class AndroidApplicationPlugin : Plugin<Project> {
                 implementation(libs.findLibrary("koin").get())
                 implementation(libs.findLibrary("timber").get())
 
-                testImplementation(project(":testing"))
-                androidTestImplementation(project(":testing"))
+                testImplementation(project(ModuleConfig.testing))
+                androidTestImplementation(project(ModuleConfig.testing))
             }
         }
     }

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidModulePlugin.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidModulePlugin.kt
@@ -3,6 +3,7 @@ package br.com.jonathanarodr.playmovie.gradlebuild.plugins
 import br.com.jonathanarodr.playmovie.gradlebuild.androidTestImplementation
 import br.com.jonathanarodr.playmovie.gradlebuild.androidTestUtil
 import br.com.jonathanarodr.playmovie.gradlebuild.apply
+import br.com.jonathanarodr.playmovie.gradlebuild.config.ModuleConfig
 import br.com.jonathanarodr.playmovie.gradlebuild.implementation
 import br.com.jonathanarodr.playmovie.gradlebuild.libs
 import br.com.jonathanarodr.playmovie.gradlebuild.testImplementation
@@ -42,8 +43,8 @@ class AndroidModulePlugin : Plugin<Project> {
 
                 androidTestUtil(libs.findLibrary("androidx-test-orchestrator").get())
 
-                testImplementation(project(":testing"))
-                androidTestImplementation(project(":testing"))
+                testImplementation(project(ModuleConfig.testing))
+                androidTestImplementation(project(ModuleConfig.testing))
             }
         }
     }

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/KotlinModulePlugin.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/KotlinModulePlugin.kt
@@ -1,6 +1,7 @@
 package br.com.jonathanarodr.playmovie.gradlebuild.plugins
 
 import br.com.jonathanarodr.playmovie.gradlebuild.apply
+import br.com.jonathanarodr.playmovie.gradlebuild.config.ModuleConfig
 import br.com.jonathanarodr.playmovie.gradlebuild.implementation
 import br.com.jonathanarodr.playmovie.gradlebuild.libs
 import br.com.jonathanarodr.playmovie.gradlebuild.testImplementation
@@ -28,7 +29,7 @@ class KotlinModulePlugin : Plugin<Project> {
 
                 implementation(libs.findLibrary("kotlinx-coroutines-core").get())
 
-                testImplementation(project(":testing"))
+                testImplementation(project(ModuleConfig.testing))
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,3 +24,5 @@ include(
     ":network",
     ":feature",
 )
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
## Goal

Enabling the `TYPESAFE_PROJECT_ACCESSORS` and using the project accessor to add submodules.