### PR TITLE
Fixing android plugin warning

### DIFF
--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidApplicationPlugin.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidApplicationPlugin.kt
@@ -32,7 +32,7 @@ class AndroidApplicationPlugin : Plugin<Project> {
                 "com.android.application",
                 "org.gradle.android.cache-fix",
                 "org.gradle.test-retry",
-                "kotlin-android",
+                "org.jetbrains.kotlin.android",
                 "kotlin-parcelize",
                 "playmovie.codestyle",
                 "playmovie.codecoverage",

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidLibraryPlugin.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidLibraryPlugin.kt
@@ -25,7 +25,7 @@ class AndroidLibraryPlugin : Plugin<Project> {
                 "com.android.library",
                 "org.gradle.android.cache-fix",
                 "org.gradle.test-retry",
-                "kotlin-android",
+                "org.jetbrains.kotlin.android",
                 "kotlin-parcelize",
                 "com.google.devtools.ksp",
             )


### PR DESCRIPTION
## Goal

Fixing warning about the use of the kotlin android plugin displayed from Android Studio Electric Eel.