### PR TITLE
Enabling test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ $RECYCLE.BIN/
 .gradle/
 build/
 /*/build/
+.kotlin/
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/common/src/test/kotlin/br/com/jonathanarodr/playmovie/common/executors/ApiExecutorTest.kt
+++ b/common/src/test/kotlin/br/com/jonathanarodr/playmovie/common/executors/ApiExecutorTest.kt
@@ -1,6 +1,6 @@
 package br.com.jonathanarodr.playmovie.common.executors
 
-import br.com.jonathanarodr.playmovie.core.testing.rules.CoroutinesTestRule
+import br.com.jonathanarodr.playmovie.testing.rules.CoroutinesTestRule
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/common/src/test/kotlin/br/com/jonathanarodr/playmovie/common/executors/StorageExecutorTest.kt
+++ b/common/src/test/kotlin/br/com/jonathanarodr/playmovie/common/executors/StorageExecutorTest.kt
@@ -1,6 +1,6 @@
 package br.com.jonathanarodr.playmovie.common.executors
 
-import br.com.jonathanarodr.playmovie.core.testing.rules.CoroutinesTestRule
+import br.com.jonathanarodr.playmovie.testing.rules.CoroutinesTestRule
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/feature/src/androidTest/kotlin/br/com/jonathanarodr/playmovie/feature/repository/local/db/MovieDaoTest.kt
+++ b/feature/src/androidTest/kotlin/br/com/jonathanarodr/playmovie/feature/repository/local/db/MovieDaoTest.kt
@@ -3,7 +3,7 @@ package br.com.jonathanarodr.playmovie.feature.repository.local.db
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.FlakyTest
 import androidx.test.filters.MediumTest
-import br.com.jonathanarodr.playmovie.core.testing.rules.RoomDatabaseRule
+import br.com.jonathanarodr.playmovie.testing.rules.RoomDatabaseRule
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/feature/src/test/kotlin/br/com/jonathanarodr/playmovie/feature/ui/viewmodel/DetailViewModelTest.kt
+++ b/feature/src/test/kotlin/br/com/jonathanarodr/playmovie/feature/ui/viewmodel/DetailViewModelTest.kt
@@ -3,10 +3,10 @@ package br.com.jonathanarodr.playmovie.feature.ui.viewmodel
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.filters.MediumTest
 import br.com.jonathanarodr.playmovie.common.states.UiState
-import br.com.jonathanarodr.playmovie.core.testing.ext.capture
-import br.com.jonathanarodr.playmovie.core.testing.rules.CoroutinesTestRule
 import br.com.jonathanarodr.playmovie.feature.domain.model.Movie
 import br.com.jonathanarodr.playmovie.feature.domain.usecase.DetailUseCase
+import br.com.jonathanarodr.playmovie.testing.ext.capture
+import br.com.jonathanarodr.playmovie.testing.rules.CoroutinesTestRule
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.mockk

--- a/feature/src/test/kotlin/br/com/jonathanarodr/playmovie/feature/ui/viewmodel/MovieViewModelTest.kt
+++ b/feature/src/test/kotlin/br/com/jonathanarodr/playmovie/feature/ui/viewmodel/MovieViewModelTest.kt
@@ -3,11 +3,11 @@ package br.com.jonathanarodr.playmovie.feature.ui.viewmodel
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.filters.MediumTest
 import br.com.jonathanarodr.playmovie.common.states.UiState
-import br.com.jonathanarodr.playmovie.core.testing.ext.capture
-import br.com.jonathanarodr.playmovie.core.testing.rules.CoroutinesTestRule
 import br.com.jonathanarodr.playmovie.feature.domain.model.Movie
 import br.com.jonathanarodr.playmovie.feature.domain.type.MovieType
 import br.com.jonathanarodr.playmovie.feature.domain.usecase.MovieUseCase
+import br.com.jonathanarodr.playmovie.testing.ext.capture
+import br.com.jonathanarodr.playmovie.testing.rules.CoroutinesTestRule
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.mockk

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidApplicationPlugin.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidApplicationPlugin.kt
@@ -69,8 +69,8 @@ class AndroidApplicationPlugin : Plugin<Project> {
                 implementation(libs.findLibrary("koin-android").get())
                 implementation(libs.findLibrary("timber").get())
 
-                testImplementation(project(ModuleConfig.testing))
-                androidTestImplementation(project(ModuleConfig.testing))
+                testImplementation(testFixtures(project(ModuleConfig.testing)))
+                androidTestImplementation(testFixtures(project(ModuleConfig.testing)))
             }
         }
     }

--- a/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidModulePlugin.kt
+++ b/gradle-build/plugins/src/main/kotlin/br/com/jonathanarodr/playmovie/gradlebuild/plugins/AndroidModulePlugin.kt
@@ -44,8 +44,8 @@ class AndroidModulePlugin : Plugin<Project> {
 
                 androidTestUtil(libs.findLibrary("androidx-test-orchestrator").get())
 
-                testImplementation(project(ModuleConfig.testing))
-                androidTestImplementation(project(ModuleConfig.testing))
+                testImplementation(testFixtures(project(ModuleConfig.testing)))
+                androidTestImplementation(testFixtures(project(ModuleConfig.testing)))
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,5 @@ kotlin.code.style=official
 android.enableJetifier=false
 android.useAndroidX=true
 android.includeDependencyInfoInApks=false
+android.experimental.enableTestFixturesKotlinSupport=true
 #android.experimental.androidTest.numManagedDeviceShards=1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ android-cachefix-gradlePlugin = { group = "org.gradle.android.cache-fix", name =
 
 # kotlin
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 kotlin-compose-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -3,7 +3,11 @@ plugins {
 }
 
 android {
-    namespace = "br.com.jonathanarodr.playmovie.core.testing"
+    namespace = "br.com.jonathanarodr.playmovie.testing"
+
+    testFixtures {
+        enable = true
+    }
 }
 
 /**

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -14,6 +14,8 @@ android {
  * FIXME create submodules to control dependencies between unitTest and androidTest
  */
 dependencies {
+    testFixturesImplementation(libs.kotlin.stdlib)
+
     implementation(libs.androidx.lifecycle.livedata)
 
     api(libs.junit)

--- a/testing/src/testFixtures/kotlin/br/com/jonathanarodr/playmovie/testing/ext/LiveDataExt.kt
+++ b/testing/src/testFixtures/kotlin/br/com/jonathanarodr/playmovie/testing/ext/LiveDataExt.kt
@@ -1,4 +1,4 @@
-package br.com.jonathanarodr.playmovie.core.testing.ext
+package br.com.jonathanarodr.playmovie.testing.ext
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer

--- a/testing/src/testFixtures/kotlin/br/com/jonathanarodr/playmovie/testing/rules/CoroutinesTestRule.kt
+++ b/testing/src/testFixtures/kotlin/br/com/jonathanarodr/playmovie/testing/rules/CoroutinesTestRule.kt
@@ -1,4 +1,4 @@
-package br.com.jonathanarodr.playmovie.core.testing.rules
+package br.com.jonathanarodr.playmovie.testing.rules
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/testing/src/testFixtures/kotlin/br/com/jonathanarodr/playmovie/testing/rules/RoomDatabaseRule.kt
+++ b/testing/src/testFixtures/kotlin/br/com/jonathanarodr/playmovie/testing/rules/RoomDatabaseRule.kt
@@ -1,4 +1,4 @@
-package br.com.jonathanarodr.playmovie.core.testing.rules
+package br.com.jonathanarodr.playmovie.testing.rules
 
 import android.content.Context
 import androidx.room.Room


### PR DESCRIPTION
## Goal

Enabling [test fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures) from test codes.

## Changes

### Kotlin support for test fixtures in Android Gradle plugin

Starting with Android Gradle plugin `8.5.0-beta01`, you can now use Kotlin in your `testFixtures` sources. Previously, `testFixtures` sources only supported Java.

To use this feature, do the following:

1. Ensure you're using Kotlin version `1.9.20` or higher.
2. Add `android.experimental.enableTestFixturesKotlinSupport=true` to your `gradle.properties` file.
3. Add an explicit dependency on the Kotlin standard library in your module's `build.gradle.kts` or `build.gradle` file:

```groovy
dependencies {
    testFixturesImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.20")
}
```

> Known limitations: There is no KAPT or KSP support for test fixtures yet.