### PR TITLE
Fixed deprecated gradle actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/setup-gradle-build
 
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
   code-quality:
     needs: [setup-workflow]
@@ -100,7 +100,7 @@ jobs:
         uses: ./.github/actions/setup-gradle-build
 
       - name: Setup gradle build
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build apks
         run: ./gradlew app:assemble


### PR DESCRIPTION
## Goal

Corrige warning sobre actions do gradle que foram depreciadas.

> Warning: This job uses deprecated functionality from the 'gradle/gradle-build-action' action. Consult the Job Summary for more details.
DEPRECATION: The action `gradle/gradle-build-action` has been replaced by `gradle/actions/setup-gradle`. See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle